### PR TITLE
fixing cone implementation

### DIFF
--- a/SCADGen/Parser.py
+++ b/SCADGen/Parser.py
@@ -68,6 +68,7 @@ class Parser:
             attrs = []
             for child in elem:
                 if self.isBinary(child) or self.isComp(child) or self.isUnary(child) or self.isNary(child):
+                    if comp1 is not None: raise RuntimeError("found more than 1 components in a Unary")
                     comp1 = child
                 else:
                     attrs.append(child)

--- a/SCADGen/components/Cone.py
+++ b/SCADGen/components/Cone.py
@@ -12,8 +12,12 @@ class Cone(Component):
         are accessed with the xml.etree.ElementTree.Element
         object, xml_elem.
         """
-        _convert = lambda x: self._convertToLength(xml_elem.get(x))
-        self.top_radius, self.height = map(_convert, "radius height".split())
+        def _convert(x):
+            value = xml_elem.get(x)
+            if value is None:
+                raise RuntimeError("was not able to get %s from %s" % (x, xml_elem))
+            return self._convertToLength(value)
+        self.radius, self.height = map(_convert, "radius height".split())
         # return
 
     def __str__(self):
@@ -21,9 +25,8 @@ class Cone(Component):
         Returns a string containing the SCAD
         code for this Cone object.
         """
-
-        return "translate([0.0, 0.0, -{0!s}]) {{cylinder(h = {1!s},  r1 = {2!s}, $fn=100, center=true);}}".format(
-            self.height/2, self.height,  self.top_radius)
+        return "translate([0.0, 0.0, -{0!s}]) {{cylinder(h = {1!s},  r1 = {2!s}, r2=0,  $fn=100, center=true);}}".format(
+            self.height/2, self.height,  self.radius)
 
     def __eq__(self, rhs):
         """
@@ -31,7 +34,7 @@ class Cone(Component):
         """
         if type(self) != type(rhs):
             return False
-        elif self.top_radius != rhs.top_radius or self.height != rhs.height:
+        elif self.radius != rhs.radius or self.height != rhs.height:
             return False
         else:
             return True

--- a/tests/comp_tests/test4.xml
+++ b/tests/comp_tests/test4.xml
@@ -4,7 +4,7 @@
 
     <intersection>
         <difference>
-            <cone height="10.*mm" topRadius="5.*mm" bottomRadius="10.*mm"/>
+            <cone height="10.*mm" radius="10.*mm"/>
             <cylinder height="10.*mm" radius="5.*mm"/>
         </difference>
         <rotation>

--- a/tests/pytest/test_Components.py
+++ b/tests/pytest/test_Components.py
@@ -15,11 +15,11 @@ def test_block():
     assert(test.x == sol[0] and test.y == sol[1] and test.z == sol[2])
 
 def test_cone():
-    fname = os.path.abspath("./tests/unittests/components/Cone_diff_radii.xml")
+    fname = os.path.abspath("./tests/unittests/components/Cone.xml")
     p = Parser(fname)
     test = p.rootelems[0]
-    sol = [5, 2, 4]
-    assert(test.bottom_radius == sol[2] and test.top_radius == sol[1] and test.height == sol[0])
+    sol = [50, 25]
+    assert(test.radius == sol[1] and test.height == sol[0])
 
 def test_cylinder():
     fname = os.path.abspath("./tests/unittests/components/Cylinder.xml")

--- a/tests/pytest/test_Nary.py
+++ b/tests/pytest/test_Nary.py
@@ -10,7 +10,7 @@ import xml.etree.ElementTree as et
 
 def test_difference_Comp1Height():
     elem1 = et.Element("cylinder", { "height" : "5.*mm", "radius" : "2.5*mm" })
-    elem2 = et.Element("cone", { "height" : "5.*mm", "topRadius" : "0.*mm", "bottomRadius" : "2.5*mm" })
+    elem2 = et.Element("cone", { "height" : "5.*mm", "radius" : "2.5*mm" })
     op = operations.Difference()
     op.addComp(components.Cylinder(elem1))
     op.addComp(components.Cone(elem2))
@@ -18,7 +18,7 @@ def test_difference_Comp1Height():
 
 def test_difference_Comp1Radius():
     elem1 = et.Element("cylinder", { "height" : "5.*mm", "radius" : "2.5*mm" })
-    elem2 = et.Element("cone", { "height" : "5.*mm", "topRadius" : "0.*mm", "bottomRadius" : "2.5*mm" })
+    elem2 = et.Element("cone", { "height" : "5.*mm", "radius" : "2.5*mm" })
     op = operations.Difference()
     op.addComp(components.Cylinder(elem1))
     op.addComp(components.Cone(elem2))
@@ -26,7 +26,7 @@ def test_difference_Comp1Radius():
 
 def test_difference_Comp2Height():
     elem1 = et.Element("cylinder", { "height" : "5.*mm", "radius" : "2.5*mm" })
-    elem2 = et.Element("cone", { "height" : "5.*mm", "topRadius" : "0.*mm", "bottomRadius" : "2.5*mm" })
+    elem2 = et.Element("cone", { "height" : "5.*mm", "radius" : "2.5*mm" })
     op = operations.Difference()
     op.addComp(components.Cylinder(elem1))
     op.addComp(components.Cone(elem2))
@@ -34,19 +34,11 @@ def test_difference_Comp2Height():
 
 def test_difference_Comp2Top():
     elem1 = et.Element("cylinder", { "height" : "5.*mm", "radius" : "2.5*mm" })
-    elem2 = et.Element("cone", { "height" : "5.*mm", "topRadius" : "0.*mm", "bottomRadius" : "2.5*mm" })
+    elem2 = et.Element("cone", { "height" : "5.*mm", "radius" : "2.5*mm" })
     op = operations.Difference()
     op.addComp(components.Cylinder(elem1))
     op.addComp(components.Cone(elem2))
-    assert(op[1].top_radius == 0)
-
-def test_difference_Comp2Bottom():
-    elem1 = et.Element("cylinder", { "height" : "5.*mm", "radius" : "2.5*mm" })
-    elem2 = et.Element("cone", { "height" : "5.*mm", "topRadius" : "0.*mm", "bottomRadius" : "2.5*mm" })
-    op = operations.Difference()
-    op.addComp(components.Cylinder(elem1))
-    op.addComp(components.Cone(elem2))
-    assert(op[1].bottom_radius == 2.5)
+    assert(op[1].radius == 2.5)
 
 def test_intersection_Comp1Radius():
     elem1 = et.Element("sphere", { "radius" : "5.*mm" })

--- a/tests/pytest/test_Parser.py
+++ b/tests/pytest/test_Parser.py
@@ -28,7 +28,7 @@ def test_parsercore():
     op5.addComp(components.Sphere(comp2))
     op5.addComp(components.Pyramid(comp3))
     op6 = operations.Union()
-    comp4 = et.Element("cone", { "height" : "20.*mm", "topRadius" : "10.*mm", "bottomRadius" : "20.*mm" })
+    comp4 = et.Element("cone", { "height" : "20.*mm", "radius" : "20.*mm" })
     comp5 = et.Element("cylinder", { "height" : "10.*mm", "radius" : "20.*mm" })
     comp6 = et.Element("torus", {"major" : "30.*mm", "minor" : "20.*mm" })
     op6.addComp(components.Cone(comp4))

--- a/tests/pytest/test_str.py
+++ b/tests/pytest/test_str.py
@@ -15,9 +15,9 @@ def test_block_str():
     assert("{0!s}".format(test) == sol)
 
 def test_cone_str():
-    elem1 = et.Element("cone", { "height" : "5.*mm", "topRadius" : "2.*mm", "bottomRadius" : "4.*mm" })
+    elem1 = et.Element("cone", { "height" : "5.*mm", "radius" : "4.*mm" })
     test = components.Cone(elem1)
-    sol = "cylinder(h = 5.0, r1 = 4.0, r2 = 2.0, $fn=100, center=true);"
+    sol = "translate([0.0, 0.0, -2.5]) {cylinder(h = 5.0,  r1 = 4.0, r2=0,  $fn=100, center=true);}"
     assert("{0!s}".format(test) == sol)
 
 def test_cylinder_str():
@@ -50,7 +50,7 @@ def test_torus_str():
 
 def test_difference_str():
     elem1 = et.Element("cylinder", { "radius" : "2.5*mm", "height" : "5.*mm" })
-    elem2 = et.Element("cone", { "bottomRadius" : "2.5*mm", "topRadius" : "0.*mm", "height" : "5.*mm" })
+    elem2 = et.Element("cone", { "radius" : "2.5*mm", "height" : "5.*mm" })
     comp1 = components.Cylinder(elem1)
     comp2 = components.Cone(elem2)
     test = operations.Difference()
@@ -58,7 +58,7 @@ def test_difference_str():
     test.addComp(comp2)
     sol = """difference() {
     cylinder(h = 5.0, r = 2.5, $fn=100, center=true);
-    cylinder(h = 5.0, r1 = 2.5, r2 = 0.0, $fn=100, center=true);
+    translate([0.0, 0.0, -2.5]) {cylinder(h = 5.0,  r1 = 2.5, r2=0,  $fn=100, center=true);}
 }"""
     assert("{0!s}".format(test) == sol)
 

--- a/tests/pytest/test_xmls/parser_sol.scad
+++ b/tests/pytest/test_xmls/parser_sol.scad
@@ -19,7 +19,7 @@ scale([3.0, 3.0, 3.0]) {
 );
 }
     union() {
-    cylinder(h = 20.0, r1 = 20.0, r2 = 10.0, $fn=100, center=true);
+    translate([0.0, 0.0, -10.0]) {cylinder(h = 20.0,  r1 = 20.0, r2=0,  $fn=100, center=true);}
     cylinder(h = 10.0, r = 20.0, $fn=100, center=true);
     Torus(30.0, 20.0);
 }

--- a/tests/pytest/test_xmls/parser_test.xml
+++ b/tests/pytest/test_xmls/parser_test.xml
@@ -13,7 +13,7 @@
                             <pyramid thickness="20.*mm" width="20.*mm" height="10.*mm"/>
                         </intersection>
                         <union>
-                            <cone height="20.*mm" topRadius="10.*mm" bottomRadius="20.*mm"/>
+                            <cone height="20.*mm" radius="20.*mm"/>
                             <cylinder height="10.*mm" radius="20.*mm"/>
                             <torus major="30.*mm" minor="20.*mm"/>
                         </union>

--- a/tests/unittests/components/Cone.xml
+++ b/tests/unittests/components/Cone.xml
@@ -2,6 +2,6 @@
 
 <geometry>
 
-    <cone height="5.*cm" topRadius="2.5*cm" bottomRadius="2.5*cm"/>
+    <cone height="5.*cm" radius="2.5*cm"/>
 
 </geometry>

--- a/tests/unittests/components/Cone_diff_radii.xml
+++ b/tests/unittests/components/Cone_diff_radii.xml
@@ -1,7 +1,0 @@
-<!DOCTYPE geometry>
-
-<geometry>
-
-    <cone height="5.*mm" topRadius="2.*mm" bottomRadius="4.*mm"/>
-
-</geometry>

--- a/tests/unittests/operations/Difference.xml
+++ b/tests/unittests/operations/Difference.xml
@@ -4,7 +4,7 @@
 
     <difference>
         <cylinder height="3.*cm" radius="0.5*cm"/>
-        <cone height="3.01*cm" topRadius="0.1*cm" bottomRadius="0.5*cm"/>
+        <cone height="3.01*cm" radius="0.5*cm"/>
     </difference>
 
 </geometry>


### PR DESCRIPTION
The original implementation assumes a cone has two radii. In the current mcvine c++ implementation the cone is defined with only one radius. @Fahima-Islam has tried to modify the implmentation but did not modify the related tests. This PR try to fix that.